### PR TITLE
Add DAO, entity and mapper structure

### DIFF
--- a/demo/src/main/java/com/fatcatdog/todo/DataLoader.java
+++ b/demo/src/main/java/com/fatcatdog/todo/DataLoader.java
@@ -8,7 +8,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 
-import com.fatcatdog.todo.model.Task;
+import com.fatcatdog.todo.entity.Task;
 import com.fatcatdog.todo.service.TaskService;
 
 //This class inputs 3 objects into the database upon booting up the application. 

--- a/demo/src/main/java/com/fatcatdog/todo/controller/TaskController.java
+++ b/demo/src/main/java/com/fatcatdog/todo/controller/TaskController.java
@@ -1,6 +1,8 @@
 package com.fatcatdog.todo.controller;
 
 import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,8 +20,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.fatcatdog.todo.DemoApplication;
-import com.fatcatdog.todo.model.Task;
+import com.fatcatdog.todo.entity.Task;
 import com.fatcatdog.todo.service.TaskService;
+import com.fatcatdog.todo.dto.TaskDto;
+import com.fatcatdog.todo.mapper.TaskMapper;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -32,19 +36,23 @@ import io.swagger.annotations.ApiOperation;
 @RequestMapping(path="/api") 
 public class TaskController {
 	
-	private static final Logger logger = LoggerFactory.getLogger(TaskController.class);
+        private static final Logger logger = LoggerFactory.getLogger(TaskController.class);
 
-	@Autowired
-	private TaskService taskService;
+        @Autowired
+        private TaskService taskService;
+
+        @Autowired
+        private TaskMapper taskMapper;
 
 	@ApiOperation(value = "Add a task")
     @CrossOrigin(origins = "*")
-	@PostMapping(path="/add", produces = "application/json; charset=UTF-8") 
-	public ResponseEntity<?> addNewTask (@RequestBody Task task) {
+        @PostMapping(path="/add", produces = "application/json; charset=UTF-8")
+        public ResponseEntity<?> addNewTask (@RequestBody TaskDto taskDto) {
 
 		try {
-			taskService.save(task);
-		    logger.info("TaskController - addNewTask: " + task);
+                        Task task = taskMapper.toEntity(taskDto);
+                        taskService.save(task);
+                    logger.info("TaskController - addNewTask: " + task);
 			return new ResponseEntity<>(HttpStatus.OK) ;
 		} catch (Exception e) {
 		    logger.error("TaskController - addNewTask: " + e);
@@ -54,12 +62,13 @@ public class TaskController {
 	
 	@ApiOperation(value = "Update a task")
     @CrossOrigin(origins = "*")
-	@PutMapping(path="/update",  produces = "application/json; charset=UTF-8") 
-	public ResponseEntity<?> updateTask (@RequestBody Task task) {
+        @PutMapping(path="/update",  produces = "application/json; charset=UTF-8")
+        public ResponseEntity<?> updateTask (@RequestBody TaskDto taskDto) {
 			        
 		try {
-			taskService.save(task);
-		    logger.info("TaskController - updateTask: " + task);
+                        Task task = taskMapper.toEntity(taskDto);
+                        taskService.save(task);
+                    logger.info("TaskController - updateTask: " + task);
 			return new ResponseEntity<>(HttpStatus.OK) ;
 		} catch (Exception e) {
 		    logger.error("TaskController - updateTask: " + e);			
@@ -70,11 +79,15 @@ public class TaskController {
 	@ApiOperation(value = "Get all tasks")
     @CrossOrigin(origins = "*")
 	@GetMapping(path = "/tasks",  produces = "application/json; charset=UTF-8") 
-	public ResponseEntity<?> getAllTasks() {
-		try {
-    		Iterable<Task> tempTasks = taskService.getAllTasks();
-		    logger.info("TaskController - getAllTasks: " + tempTasks);
-    		return new ResponseEntity<>(tempTasks, HttpStatus.OK); 
+        public ResponseEntity<?> getAllTasks() {
+                try {
+                Iterable<Task> tempTasks = taskService.getAllTasks();
+                List<TaskDto> dtos = new ArrayList<>();
+                for (Task t : tempTasks) {
+                    dtos.add(taskMapper.toDto(t));
+                }
+                    logger.info("TaskController - getAllTasks: " + dtos);
+                return new ResponseEntity<>(dtos, HttpStatus.OK);
 		} catch (Exception e) {
 			System.out.println(e);
 		    logger.error("TaskController - getAllTasks: " + e);
@@ -85,11 +98,12 @@ public class TaskController {
 	@ApiOperation(value = "Get a task by Task id(int)")
     @CrossOrigin(origins = "*")
 	@GetMapping(path = "/get/{id}",  produces = "application/json; charset=UTF-8") 
-	public ResponseEntity<?> getTaskById(@PathVariable(name = "id") int id) {
-		try {
-    		Optional<Task> tempTask = taskService.getTask((id));
-		    logger.info("TaskController - getTaskById: " + " id: " + id  + " task: " + tempTask);
-    		return new ResponseEntity<>(tempTask, HttpStatus.OK); 
+        public ResponseEntity<?> getTaskById(@PathVariable(name = "id") int id) {
+                try {
+                Optional<Task> tempTask = taskService.getTask((id));
+                Optional<TaskDto> dto = tempTask.map(taskMapper::toDto);
+                    logger.info("TaskController - getTaskById: " + " id: " + id  + " task: " + dto);
+                return new ResponseEntity<>(dto, HttpStatus.OK);
 		} catch (Exception e) {
 		    logger.error("TaskController - getTaskById: " + e);
     		return new ResponseEntity<>(HttpStatus.BAD_REQUEST); 
@@ -98,12 +112,13 @@ public class TaskController {
     
 	@ApiOperation(value = "Delete a task")
     @CrossOrigin(origins = "*")
-   	@DeleteMapping(path="/delete", produces = "application/json; charset=UTF-8") 
-   	public ResponseEntity<?> deleteTask (@RequestBody Task task) {
+        @DeleteMapping(path="/delete", produces = "application/json; charset=UTF-8")
+        public ResponseEntity<?> deleteTask (@RequestBody TaskDto taskDto) {
 
 		try {
-   			taskService.delete(task);
-		    logger.info("TaskController - deleteTask: " + task);
+                        Task task = taskMapper.toEntity(taskDto);
+                        taskService.delete(task);
+                    logger.info("TaskController - deleteTask: " + task);
     		return new ResponseEntity<>(HttpStatus.OK); 
    		} catch (Exception e) {
 		    logger.error("TaskController - deleteTask: " + e);
@@ -115,12 +130,13 @@ public class TaskController {
 	@ApiOperation(value = "Fetch a task by code")
     @CrossOrigin(origins = "*")
    	@GetMapping(path="/code/{code}", produces = "application/json; charset=UTF-8") 
-   	public ResponseEntity<?> getTaskByCode (@PathVariable(name = "code") int code) {
+        public ResponseEntity<?> getTaskByCode (@PathVariable(name = "code") int code) {
 
 		try {
-			Optional<Task> tempTask = taskService.getTaskByCode(code);
-		    logger.info("TaskController - getTaskByCode: " + code);
-    		return new ResponseEntity<>(tempTask, HttpStatus.OK); 
+                        Optional<Task> tempTask = taskService.getTaskByCode(code);
+                        Optional<TaskDto> dto = tempTask.map(taskMapper::toDto);
+                    logger.info("TaskController - getTaskByCode: " + code);
+                return new ResponseEntity<>(dto, HttpStatus.OK);
    		} catch (Exception e) {
 		    logger.error("TaskController - getTaskByCode: " + code);
     		return new ResponseEntity<>(HttpStatus.BAD_REQUEST); 

--- a/demo/src/main/java/com/fatcatdog/todo/dao/TaskDao.java
+++ b/demo/src/main/java/com/fatcatdog/todo/dao/TaskDao.java
@@ -1,17 +1,19 @@
-package com.fatcatdog.todo.repository;
+package com.fatcatdog.todo.dao;
 
 import java.util.Optional;
 
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.fatcatdog.todo.model.Task;
+import com.fatcatdog.todo.entity.Task;
 
 //this class uses Spring JPA's CrudRepository to bring in all of our methods/functionality. 
 //This class is used by our taskservice class
-public interface TaskRepository extends CrudRepository<Task, Integer> {
+@Repository
+public interface TaskDao extends CrudRepository<Task, Integer> {
 
 	//this is a custom JPA query to fetch tasks by code
 	Optional<Task> findByCode(int code);

--- a/demo/src/main/java/com/fatcatdog/todo/dto/TaskDto.java
+++ b/demo/src/main/java/com/fatcatdog/todo/dto/TaskDto.java
@@ -1,0 +1,71 @@
+package com.fatcatdog.todo.dto;
+
+import java.util.Date;
+
+public class TaskDto {
+    private Integer id;
+    private String name;
+    private String description;
+    private Date dueDate;
+    private int code;
+    private boolean status;
+
+    public TaskDto() {}
+
+    public TaskDto(Integer id, String name, String description, Date dueDate, int code, boolean status) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.dueDate = dueDate;
+        this.code = code;
+        this.status = status;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Date getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(Date dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    public boolean isStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+}

--- a/demo/src/main/java/com/fatcatdog/todo/entity/Task.java
+++ b/demo/src/main/java/com/fatcatdog/todo/entity/Task.java
@@ -1,4 +1,4 @@
-package com.fatcatdog.todo.model;
+package com.fatcatdog.todo.entity;
 
 import java.util.Date;
 

--- a/demo/src/main/java/com/fatcatdog/todo/mapper/TaskMapper.java
+++ b/demo/src/main/java/com/fatcatdog/todo/mapper/TaskMapper.java
@@ -1,0 +1,38 @@
+package com.fatcatdog.todo.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.fatcatdog.todo.dto.TaskDto;
+import com.fatcatdog.todo.entity.Task;
+
+@Component
+public class TaskMapper {
+
+    public TaskDto toDto(Task task) {
+        if (task == null) {
+            return null;
+        }
+        TaskDto dto = new TaskDto();
+        dto.setId(task.getId());
+        dto.setName(task.getName());
+        dto.setDescription(task.getDescription());
+        dto.setDueDate(task.getDueDate());
+        dto.setCode(task.getCode());
+        dto.setStatus(task.isStatus());
+        return dto;
+    }
+
+    public Task toEntity(TaskDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        Task task = new Task();
+        task.setId(dto.getId());
+        task.setName(dto.getName());
+        task.setDescription(dto.getDescription());
+        task.setDueDate(dto.getDueDate());
+        task.setCode(dto.getCode());
+        task.setStatus(dto.isStatus());
+        return task;
+    }
+}

--- a/demo/src/main/java/com/fatcatdog/todo/service/TaskService.java
+++ b/demo/src/main/java/com/fatcatdog/todo/service/TaskService.java
@@ -7,58 +7,58 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.fatcatdog.todo.model.Task;
-import com.fatcatdog.todo.repository.TaskRepository;
+import com.fatcatdog.todo.entity.Task;
+import com.fatcatdog.todo.dao.TaskDao;
 
 //@Service  brings in appropriate beans
-//This class brings in an instance of our TaskRepository to add more abstraction user from DB
+//This class brings in an instance of our TaskDao to add more abstraction between controller and database
 @Service
 public class TaskService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(TaskService.class);
 
 	@Autowired
-	private TaskRepository taskRepository;
+        private TaskDao taskDao;
 	
 
-	public TaskService(TaskRepository taskRepository) {
-	    this.taskRepository = taskRepository;
-	}
+        public TaskService(TaskDao taskDao) {
+            this.taskDao = taskDao;
+        }
 
 	public Iterable<Task> getAllTasks(){
 
 	    logger.info("TaskService getAllTasks");
-		return taskRepository.findAll();
+                return taskDao.findAll();
 	}
 	
 	public void save(Task task) {
 
 	    logger.info("TaskService save");
 	    logger.info("Task: " + task);
-		taskRepository.save(task);
+                taskDao.save(task);
 	}
 	
 	public void delete(Task task) {
 		logger.info("TaskService delete");
 	    logger.info("Task: " + task);
-		taskRepository.delete(task);
+                taskDao.delete(task);
 	}
 	
 	public Optional<Task> getTask(int id) {
 		logger.info("TaskService getTask");
 	    logger.info("Task id: " + id);
-	    return taskRepository.findById(id);
+            return taskDao.findById(id);
 	}
 
 	public Optional<Task> getTaskByCode(int code) {
 		logger.info("TaskService getTaskByCode");
 	    logger.info("Task code: " + code);
-	    return taskRepository.findByCode(code);
+            return taskDao.findByCode(code);
 	}
 	
 	public Optional<Integer> findMaxCode() {
 		logger.info("TaskService getMaxCode");
-		Optional<Integer> number = taskRepository.findMaxCode();
+                Optional<Integer> number = taskDao.findMaxCode();
 	    logger.info("Task number: " + number);
 	    
 		return number;


### PR DESCRIPTION
## Summary
- create `entity`, `dao`, `dto` and `mapper` layers
- refactor `TaskService` and controller to use the new layers
- keep existing endpoints but convert to and from `TaskDto`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840fe84db6c832e9a0896f12801f225